### PR TITLE
add a custom polyfiles file instead of include entire core-js library.

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -10,7 +10,7 @@ function resolve(dir) {
 
 module.exports = {
   entry: {
-    app: ['core-js', './src/main.ts']
+    app: ['./src/main.ts']
   },
   output: {
     path: config.build.assetsRoot,

--- a/src/infrastructure/utils/polyfills.ts
+++ b/src/infrastructure/utils/polyfills.ts
@@ -1,0 +1,10 @@
+// Reduce the bundle size by import used features only.
+
+// import 'core-js/fn/promise'
+// import 'core-js/modules/es6.object.assign'
+// import 'core-js/modules/es6.object.keys'
+// import 'core-js/modules/es6.array.find'
+
+// or shim only to import all standard es6 features.
+
+require('core-js/shim');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+// import core-js polyfill at the top of source code, so they're available in everywhere.
+import './infrastructure/utils/polyfills'
 // Make sure global style is imported before App component, so the global style can't overwrite component styles.
 import 'src/styles/style.scss'
 import 'bootstrap/dist/js/bootstrap'


### PR DESCRIPTION
related issue: https://github.com/reactivesw/customer-web/issues/6 